### PR TITLE
Changing the parameterized file to use COUNT_BIG(*)

### DIFF
--- a/inst/sql/non-parametized/iris-autoTranslate-ms sql pdw.dsql
+++ b/inst/sql/non-parametized/iris-autoTranslate-ms sql pdw.dsql
@@ -43,20 +43,20 @@ USE irisResultsSchema;
 
 --For Oracle: drop temp tables if they already exist
 
-IF OBJECT_ID('iris_A', 'U') IS NOT NULL
-  DROP TABLE iris_A;
+IF XACT_STATE() = 1 COMMIT; IF OBJECT_ID('iris_A', 'U') IS NOT NULL  DROP TABLE  iris_A;
 
 
 
 --start of analysis
 
 
-create table iris_A
-(
+IF XACT_STATE() = 1 COMMIT; CREATE TABLE   iris_A
+ (
 	measure varchar(20) not null,
         result bigint,
         explanation varchar(255)
-);
+)
+WITH (DISTRIBUTION = REPLICATE);
 
 
 INSERT INTO iris_A (measure, result, explanation)

--- a/inst/sql/sql_server/iris_parameterized.sql
+++ b/inst/sql/sql_server/iris_parameterized.sql
@@ -63,7 +63,7 @@ create table @studyName_A
 select  '02G2',a.cnt, 'count of patients'
 FROM
 (
-	select count(*) cnt from @cdmSchema.person
+	select COUNT_BIG(*) cnt from @cdmSchema.person
 ) a
 ;
 
@@ -76,13 +76,13 @@ select  '01G1',a.cnt, 'count of events'
 FROM
 (
 select 
-(select count(*)   from @cdmSchema.person)
-+(select count(*)  from @cdmSchema.observation)
-+(select count(*)  from @cdmSchema.condition_occurrence)
-+(select count(*)  from @cdmSchema.drug_exposure)
-+(select count(*)  from @cdmSchema.visit_occurrence)
-+(select count(*)  from @cdmSchema.death)
-+(select count(*)  from @cdmSchema.procedure_occurrence) cnt
+(select COUNT_BIG(*)   from @cdmSchema.person)
++(select COUNT_BIG(*)  from @cdmSchema.observation)
++(select COUNT_BIG(*)  from @cdmSchema.condition_occurrence)
++(select COUNT_BIG(*)  from @cdmSchema.drug_exposure)
++(select COUNT_BIG(*)  from @cdmSchema.visit_occurrence)
++(select COUNT_BIG(*)  from @cdmSchema.death)
++(select COUNT_BIG(*)  from @cdmSchema.procedure_occurrence) cnt
 ) a
 ;
 
@@ -91,7 +91,7 @@ select
 select  'D2',a.cnt, 'count of patients with at least 1 Dx and 1 Rx'
 FROM
 (
-  select count(*) cnt from
+  select COUNT_BIG(*) cnt from
   (
   select distinct person_id from @cdmSchema.condition_occurrence
   intersect
@@ -105,7 +105,7 @@ FROM
 select  'D3',a.cnt, 'count of patients with at least 1 Dx and 1 Proc'
 FROM
 (
-  select count(*) cnt from
+  select COUNT_BIG(*) cnt from
   (
   select distinct person_id from @cdmSchema.condition_occurrence
   intersect
@@ -119,7 +119,7 @@ FROM
 select  'D4',a.cnt, 'count of patients with at least 1 Obs, 1 Dx and 1 Rx'
 FROM
 (
-  select count(*) cnt from
+  select COUNT_BIG(*) cnt from
   (
   select distinct person_id from @cdmSchema.observation
   intersect
@@ -135,7 +135,7 @@ FROM
 select  'D5',a.cnt, 'count of deceased patients'
 FROM
 (
-  select count(*) cnt from @cdmSchema.death  
+  select COUNT_BIG(*) cnt from @cdmSchema.death  
 ) a
 ;
 


### PR DESCRIPTION
Changing the parameterized file to use COUNT_BIG(_) since some SQL Server data sources have an overflow when using COUNT(_) due to the size of the tables.
